### PR TITLE
Add support for changing local number for workspace

### DIFF
--- a/i3wsgroups/i3_workspace_groups.py
+++ b/i3wsgroups/i3_workspace_groups.py
@@ -704,3 +704,16 @@ class WorkspaceGroupsController:
         new_global_name = create_workspace_name(ws_metadata)
         self.send_i3_command('rename workspace "{}" to "{}"'.format(
             focused_workspace.name, new_global_name))
+
+    def renumber_focused_workspace(self, new_local_number: int) -> None:
+        group_to_workspaces = get_group_to_workspaces(
+            self.get_monitor_workspaces())
+        # Organize the workspace groups to ensure they are consistent and every
+        # workspace has a global number.
+        self.organize_workspace_groups(group_to_workspaces)
+        focused_workspace = self.get_tree().find_focused().workspace()
+        ws_metadata = parse_workspace_name(focused_workspace.name)
+        ws_metadata.local_number = new_local_number
+        new_global_name = create_workspace_name(ws_metadata)
+        self.send_i3_command('rename workspace "{}" to "{}"'.format(
+            focused_workspace.name, new_global_name))

--- a/scripts/i3-workspace-groups
+++ b/scripts/i3-workspace-groups
@@ -101,6 +101,9 @@ def _create_args_parser() -> argparse.ArgumentParser:
         help='Similar to i3\'s "renamed workspace" command, but only changes '
         'the name of the workspace within the group, while preserving its '
         'group assignment').add_argument('new_name')
+    subparsers.add_parser(
+        'renumber-workspace',
+        help='Change local number of workspace').add_argument('new_number', type=int)
     switch_active_group_parser = subparsers.add_parser(
         'switch-active-group',
         help='Switches the active group to the one provided.')
@@ -185,6 +188,8 @@ def main():
             controller.move_workspace_relative(-1)
         elif args.command == 'rename-workspace':
             controller.rename_focused_workspace(args.new_name)
+        elif args.command == 'renumber-workspace':
+            controller.renumber_focused_workspace(args.new_number)
         elif args.command == 'switch-active-group':
             controller.switch_active_group(args.group,
                                            args.focused_monitor_only)


### PR DESCRIPTION
This i3 addon seems perfect as I always end up with too many workspaces.  When moving a workspace into a workspace group, I often want to change the workspace number.  I could not find any way to do this (my attempts using i3-msg "rename workspace to x:x:x:x:x" certainly didn't lead to anything but confusion and frustration), so I've added a command for this.