### PR TITLE
Add --monitor-only args to list-groups/workspaces commands

### DIFF
--- a/scripts/i3-assign-workspace-to-group
+++ b/scripts/i3-assign-workspace-to-group
@@ -14,7 +14,7 @@ function command_exists() {
 }
 
 function list_groups() {
-  groups="$("${TOOL}" list-groups)"
+  groups="$("${TOOL}" list-groups --monitor-only)"
   if ! echo "${groups}" | grep -qE '^$'; then
     echo ''
   fi

--- a/scripts/i3-focus-on-workspace
+++ b/scripts/i3-focus-on-workspace
@@ -18,11 +18,11 @@ TOOL="${DIR}/i3-workspace-groups"
 command_exists "${TOOL}" || TOOL="i3-workspace-groups"
 
 mesg='<span alpha="50%">Will focus on the selected workspace</span>'
-if selected_index="$("${TOOL}" list-workspaces \
+if selected_index="$("${TOOL}" list-workspaces --monitor-only \
   --fields 'group,local_number,window_icons,static_name' |
   rofi -format d -dmenu -no-custom -width 30 -p 'Workspace' \
     -mesg "${mesg}")"; then
-  selected_workspace="$("${TOOL}" list-workspaces --fields 'global_name' |
+  selected_workspace="$("${TOOL}" list-workspaces --monitor-only --fields 'global_name' |
     head -"${selected_index}" | tail -1)"
   i3-msg 'workspace --no-auto-back-and-forth "'"${selected_workspace}"'"'
 else

--- a/scripts/i3-move-to-workspace
+++ b/scripts/i3-move-to-workspace
@@ -17,11 +17,11 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 TOOL="${DIR}/i3-workspace-groups"
 command_exists "${TOOL}" || TOOL="i3-workspace-groups"
 mesg='<span alpha="50%">Focused container will move to the selected workspace</span>'
-if selected_index="$("${TOOL}" list-workspaces \
+if selected_index="$("${TOOL}" list-workspaces --monitor-only \
   --fields 'group,local_number,window_icons,static_name' |
   rofi -format d -dmenu -no-custom -width 30 -p 'Workspace' \
     -mesg "${mesg}")"; then
-  selected_workspace="$("${TOOL}" list-workspaces --fields 'global_name' |
+  selected_workspace="$("${TOOL}" list-workspaces --monitor-only --fields 'global_name' |
     head -"${selected_index}" | tail -1)"
   i3-msg 'move container to workspace "'"${selected_workspace}"'"'
 else

--- a/scripts/i3-rename-workspace
+++ b/scripts/i3-rename-workspace
@@ -17,7 +17,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 TOOL="${DIR}/i3-workspace-groups"
 command_exists "${TOOL}" || TOOL="i3-workspace-groups"
 mesg=()
-if current_name="$("${TOOL}" list-workspaces --fields static_name --focused-only)"; then
+if current_name="$("${TOOL}" list-workspaces --monitor-only --fields static_name --focused-only)"; then
   mesg[1]='-mesg'
   mesg[2]="$(printf '<span alpha="50%%">Current name: "%s"</span>' "${current_name}")"
 fi

--- a/scripts/i3-switch-active-workspace-group
+++ b/scripts/i3-switch-active-workspace-group
@@ -14,7 +14,7 @@ function command_exists() {
 }
 
 function list_groups() {
-  groups="$("${TOOL}" list-groups)"
+  groups="$("${TOOL}" list-groups --monitor-only)"
   if ! echo "${groups}" | grep -qE '^$'; then
     echo ''
   fi

--- a/scripts/i3-workspace-groups
+++ b/scripts/i3-workspace-groups
@@ -48,8 +48,12 @@ def _create_args_parser() -> argparse.ArgumentParser:
     group_arg_group.add_argument('--group-name')
     subparsers = parser.add_subparsers(dest='command')
     subparsers.required = True
-    subparsers.add_parser(
+    list_groups_parser = subparsers.add_parser(
         'list-groups', help='List the groups of the current workspaces.')
+    list_groups_parser.add_argument(
+        '--monitor-only',
+        action='store_true',
+        help='List only workspaces on the current monitor.')
     list_workspaces_parser = subparsers.add_parser(
         'list-workspaces', help='List workspaces and their group.')
     list_workspaces_parser.add_argument(
@@ -60,6 +64,10 @@ def _create_args_parser() -> argparse.ArgumentParser:
         '--focused-only',
         action='store_true',
         help='List only the focused workspace in the given group context.')
+    list_workspaces_parser.add_argument(
+        '--monitor-only',
+        action='store_true',
+        help='List only workspaces on the current monitor.')
     subparsers.add_parser(
         'workspace-number',
         help='Focus on the workspace with the provided number in the focused '
@@ -146,7 +154,7 @@ def _print_workspaces(controller, args):
             sys.exit('Invalid field: "{}". Valid fields: {}'.format(
                 field, _LIST_WORKSPACES_FIELDS))
     table = []
-    for workspace in controller.list_workspaces(args.focused_only):
+    for workspace in controller.list_workspaces(args.focused_only, args.monitor_only):
         row = []
         for field in fields:
             row.append(_get_workspace_field(workspace, field))
@@ -167,7 +175,7 @@ def main():
         args.window_icons_all_groups, args.renumber_workspaces, args.dry_run)
     try:
         if args.command == 'list-groups':
-            print('\n'.join(controller.list_groups()))
+            print('\n'.join(controller.list_groups(args.monitor_only)))
         elif args.command == 'list-workspaces':
             _print_workspaces(controller, args)
         elif args.command == 'workspace-number':


### PR DESCRIPTION
Previously, there wasn't a way to get a list of all groups/workspaces via the cli. 

This PR changes the default behavior of the commands `list-groups` and `list-workspaces` to display groups/workspaces on all monitors unless the `--monitor-only` argument is passed, in which case the previous behavior is restored.

My reasoning for changing the default behavior:

- intuition: I feel the `list-workspaces`/`list-groups` commands being so named implies that a list of _all_ workspaces/groups will be output; narrowing the selection to the current monitor by default may be unexpected, and makes more sense behind a named argument.
- consistency: I followed the convention set by `list-workspaces`'s `--focused-only` argument in acting to narrow the selection. 