### PR TITLE
Add a note about the install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,8 @@ group is usually displayed as "&lt;default>".
 The scripts can be installed using pip:
 
 ```shell
-pip install i3-workspace-groups
+python3 -m pip install i3-workspace-groups
 ```
-
-*Note: The project run under Python 3 be careful to use the right pip.*
 
 Then you should be able to run the command line tool
 [`i3-workspace-groups`](scripts/i3-workspace-groups).

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ The scripts can be installed using pip:
 pip install i3-workspace-groups
 ```
 
+*Note: The project run under Python 3 be careful to use the right pip.*
+
 Then you should be able to run the command line tool
 [`i3-workspace-groups`](scripts/i3-workspace-groups).
 There are also a few utility scripts provided that require


### PR DESCRIPTION
For many distributions, pip still use Python 2. Add a note to specify to
use the right pip.