### PR TITLE
Polybar module & multi-monitor group switching

### DIFF
--- a/i3wsgroups/controller.py
+++ b/i3wsgroups/controller.py
@@ -182,8 +182,8 @@ class WorkspaceGroupsController:
             if target_group in group_to_monitor_workspaces:
                 workspace_name = group_to_monitor_workspaces[target_group][
                     0].name
-            # The focused monitor doesn't have any workspaces in the target group,
-            # so create one.
+            # The focused monitor doesn't have any workspaces in the target
+            # group, so create one.
             else:
                 workspace_name = self._create_new_active_group_workspace_name(
                     focused_monitor_name, target_group)

--- a/i3wsgroups/i3_proxy.py
+++ b/i3wsgroups/i3_proxy.py
@@ -6,11 +6,9 @@ from i3wsgroups import logger
 
 logger = logger.logger
 
-class I3Proxy:
 
-    def __init__(self,
-                 i3_connection: i3ipc.Connection,
-                 dry_run: bool = True):
+class I3Proxy:
+    def __init__(self, i3_connection: i3ipc.Connection, dry_run: bool = True):
         self.i3_connection = i3_connection
         self.dry_run = dry_run
         # i3 tree is cached for performance. Timing the i3ipc get_tree function
@@ -42,11 +40,19 @@ class I3Proxy:
             con = con.parent
         return con.name
 
-    def get_monitor_workspaces(self, monitor_name: Optional[str] = None
-                              ) -> List[i3ipc.Con]:
+    def get_monitor_workspaces(self,
+                               monitor_name: Optional[str] = None
+                               ) -> List[i3ipc.Con]:
         if monitor_name is None:
             monitor_name = self.get_focused_monitor_name()
         return self.get_monitor_to_workspaces()[monitor_name]
+
+    def get_active_monitor_names(self) -> List[str]:
+        active_monitor_names = [
+            output.name for output in self.i3_connection.get_outputs()
+            if output.active
+        ]
+        return active_monitor_names
 
     def get_monitor_to_workspaces(self) -> Dict[str, List[i3ipc.Con]]:
         active_monitor_names = [
@@ -74,7 +80,8 @@ class I3Proxy:
             if not reply.success:
                 logger.warning('i3 command error: %s', reply.error)
 
-    def focus_workspace(self, name: str,
+    def focus_workspace(self,
+                        name: str,
                         auto_back_and_forth: bool = True) -> None:
         options = ''
         if not auto_back_and_forth:

--- a/scripts/i3-groups-polybar-module
+++ b/scripts/i3-groups-polybar-module
@@ -82,7 +82,7 @@ for group in $groups; do
     text=$text"%{A1:$(ch_gr $group):}$group:%{A}"
     i=1
 
-    ws_in_current_group=$(echo "$wmctrl" | grep ":$group:")
+    ws_in_current_group=$(echo "$wmctrl" | grep ":$group:" | sort -t : -k 3)
     ws_prev=$(echo "$ws_in_current_group" | head -1 | cut -f 3 -d ':')
     ws_last=$(echo "$ws_in_current_group" | tail -1 | cut -f 3 -d ':')
 


### PR DESCRIPTION
Hello,

There was a problem with the polybar module on a multi-screen setup. The workspaces were not ordered, so the first commit fixes that.

I also observed that if you have a multi monitor setup and you change the active group the focused workspace changes only on the focused monitor. This leads to a confusion (at least for me), because you then have one group on one monitor and one group in the other. I think I fixed this with the second commit.

What do you think about that? I am available to make things proper if there are some problems.