### PR TITLE
Add 'focused' field to list-workspaces command

### DIFF
--- a/scripts/i3-workspace-groups
+++ b/scripts/i3-workspace-groups
@@ -14,7 +14,7 @@ from i3wsgroups import controller as i3_groups_controller
 from i3wsgroups import i3_proxy, logger, workspace_names
 
 _LIST_WORKSPACES_FIELDS = workspace_names.WORKSPACE_NAME_SECTIONS + [
-    'window_icons', 'global_name', 'monitor'
+    'window_icons', 'global_name', 'monitor', 'focused'
 ]
 _LIST_WORKSPACES_FIELDS_HELP = (
     'Comma separated list of fields to output. Options: {}').format(
@@ -179,6 +179,8 @@ def _create_group_context(args):
 def _get_workspace_field(controller, workspace, field):
     if field == 'global_name':
         return workspace.name
+    if field == 'focused':
+        return 1 if workspace.find_focused() is not None else 0
     if field == 'monitor':
         con = workspace
         while con.type != 'output':


### PR DESCRIPTION
For each workspace, if the focused container is inside the workspace, the `focused` field will be `1`, else it will be `0`. The field was added at the end of the field list to avoid breaking anyone's scripts that rely on hard-coded field offsets.

Example output:

```
$ i3-workspace-groups list-workspaces
100001	fr			1		100001:​fr​​​:1	DP-1	0
100002	fr			2	4x	100002:​fr​​​:2	DP-1	0
100101	lwd			1	3x	100101:​lwd​​​:1	DP-1	0
100201	sw			1		100201:​sw​​​:1	DP-1	0
100202	sw			2		100202:​sw​​​:2	DP-1	0
100203	sw			3		100203:​sw​​​:3	DP-1	1
100301	v			1		100301:​v​​​:1	DP-1	0
100401	sk			1		100401:​sk​​​:1	DP-1	0
100501	ff			1		100501:​ff​​​:1	DP-1	0
100601	zx			1		100601:​zx​​​:1	DP-1	0
200001	prev			1		200001:​prev​​​:1	DP-2	0
200101	mon			1		200101:​mon​​​:1	DP-2	0
101	doc			1		101:​doc​​​:1	DP-3	0
102	doc	fr		2	3x	102:​doc​:fr​​:2	DP-3	0
201	log			1		201:​log​​​:1	DP-3	0

$ i3-workspace-groups list-workspaces --fields=global_name,focused
100001:​fr​​​:1	0
100002:​fr​​​:2	0
100101:​lwd​​​:1	0
100201:​sw​​​:1	0
100202:​sw​​​:2	0
100203:​sw​​​:3	1
100301:​v​​​:1	0
100401:​sk​​​:1	0
100501:​ff​​​:1	0
100601:​zx​​​:1	0
200001:​prev​​​:1	0
200101:​mon​​​:1	0
101:​doc​​​:1	0
102:​doc​:fr​​:2	0
201:​log​​​:1	0

$ i3-workspace-groups list-workspaces --group-focused
100201	sw			1		100201:​sw​​​:1	DP-1	0
100202	sw			2		100202:​sw​​​:2	DP-1	0
100203	sw			3		100203:​sw​​​:3	DP-1	1

$ i3-workspace-groups list-workspaces --group-active
100001	fr			1		100001:​fr​​​:1	DP-1	0
100002	fr			2	4x	100002:​fr​​​:2	DP-1	0

$ i3-workspace-groups list-workspaces --focused-only
100203	sw			3		100203:​sw​​​:3	DP-1	1

$ i3-workspace-groups list-workspaces --focused-monitor-only
100001	fr			1		100001:​fr​​​:1	DP-1	0
100002	fr			2	4x	100002:​fr​​​:2	DP-1	0
100101	lwd			1	3x	100101:​lwd​​​:1	DP-1	0
100201	sw			1		100201:​sw​​​:1	DP-1	0
100202	sw			2		100202:​sw​​​:2	DP-1	0
100203	sw			3		100203:​sw​​​:3	DP-1	1
100301	v			1		100301:​v​​​:1	DP-1	0
100401	sk			1		100401:​sk​​​:1	DP-1	0
100501	ff			1		100501:​ff​​​:1	DP-1	0
100601	zx			1		100601:​zx​​​:1	DP-1	0

$ i3-workspace-groups list-workspaces --help # Help message is correct
usage: i3-workspace-groups list-workspaces [-h] [--group-active | --group-focused | --group-name GROUP_NAME]
                                           [--fields FIELDS] [--focused-only] [--focused-monitor-only]

optional arguments:
  -h, --help            show this help message and exit
  --group-active        Use the active group for commands that implicitly assume a group, such as workspace-next.
  --group-focused       Use the focused group for commands that implicitly assume a group, such as workspace-next.
  --group-name GROUP_NAME
  --fields FIELDS       Comma separated list of fields to output. Options: global_number, group, static_name,
                        dynamic_name, local_number, window_icons, global_name, monitor, focused
  --focused-only        List only the focused workspace in the given group context.
  --focused-monitor-only
                        List only workspaces on the current monitor.

$ i3-workspace-groups list-workspaces --fields=foo # Error message is correct
Invalid field: "foo". Valid fields: ['global_number', 'group', 'static_name', 'dynamic_name', 'local_number', 'window_icons', 'global_name', 'monitor', 'focused']
```

I was concerned that the way `i3ipc-python` traverses the subtree tree for each workspace to find the focused container would impact performance, but any impact seems negligible with 15 workspaces and 65 containers:

```
$ hyperfine --warmup 10 -m 100 'i3-workspace-groups list-workspaces' # Before
Benchmark #1: i3-workspace-groups list-workspaces
  Time (mean ± σ):      86.2 ms ±   3.8 ms    [User: 82.8 ms, System: 10.3 ms]
  Range (min … max):    79.3 ms … 103.1 ms    100 runs

$ hyperfine --warmup 10 -m 100 'i3-workspace-groups list-workspaces' # After
Benchmark #1: i3-workspace-groups list-workspaces
  Time (mean ± σ):      85.5 ms ±   3.2 ms    [User: 80.7 ms, System: 11.3 ms]
  Range (min … max):    79.7 ms …  97.6 ms    100 runs
```

This allows me to create a mapping to focus the next group:

```
$ i3-workspace-groups list-workspaces --focused-monitor-only --fields=group,local_number,focused \
  | awk 'NR == 1 { first = $1 " " $2 } $3 { cur=$1; next }; cur && $1 != cur { print $1 " " $2; cur = ""; exit }; END { if(cur) print first }' \
  | xargs i3-workspace-groups workspace-number --group-name
```