### PR TITLE
Support pinned workspaces

### DIFF
--- a/scripts/i3-groups-polybar-module
+++ b/scripts/i3-groups-polybar-module
@@ -1,11 +1,12 @@
 #!/bin/bash
-while getopts c:e:s flag; do
+while getopts c:e:m:s flag; do
     case "${flag}" in
     e) COLOR_EXTERNAL_MONITOR=${OPTARG} ;;
     c) COLOR_CURRENT_WS=${OPTARG} ;;
     s) SHORTHAND_ENABLED=1 ;;
+    m) CURRENT_MONITOR=${OPTARG} ;;
     *) echo "Check options: valid ones\
--c \"#HEXCOLOR\", -e \"#HEXCOLOR\",\
+-c \"#HEXCOLOR\", -e \"#HEXCOLOR\",\ -m \"#MONITOR_NAME\",\
 -s Enable shorthand notation for workspaces" ;;
     esac
 done
@@ -44,8 +45,9 @@ function txt_item() {
 }
 
 fixed_wmctrl=$(
+    export current_monitor_VP=$(polybar --list-monitors | grep $CURRENT_MONITOR | cut -f 2 -d ' ' | cut -f 2- -d '+' | tr + ,);
     wmctrl -d |
-        sed -e "s/$(echo -ne '\u200b')//g"
+        sed -e "s/$(echo -ne '\u200b')//g" | grep "$current_monitor_VP"
 )
 
 current_ws_name=$(


### PR DESCRIPTION
## What's This?

The polybar module is great but does not support pinned workspaces like the `internal/i3` module.

Pinning workspaces means only showing workspaces defined on the same output of a bar. This is useful if you want to show monitor specific workspaces on different bars.

These changes add a `-m` flag to the `i3-groups-polybar-module` script which allows you to specify a monitor for which to show workspaces.

In order to use the `-m` flag, you must update the hook script flags. This is how I do it.

When calling polybar I export an environment variable called `I3_MOD_HOOK` with the monitor specifying script to call:
```
export I3_MOD_HOOK="i3-groups-polybar-module -m \"$MONITOR\""
polybar -q main -c "$dir/$style/config.ini" &
```
Then in the module configuration I set the hook value equal to this environment variable as follows:
```
[module/i3-mod]
type = custom/ipc
hook-0 = ${env:I3_MOD_HOOK}
initial = 1
```

It would have been nice to just pass the monitor as an environment variable instead of the whole script, but I couldn't find a nice way to do this because of polybar's configuration limitations: https://github.com/polybar/polybar/issues/954

This PR is a draft. I have only tested it on my machine. It identifies monitors based on their viewport position. If there is interest I can try to improve it to be more robust to variant across machines.

### Screenshots

This is what it looks like on my machine.

Monitor 1
![image](https://user-images.githubusercontent.com/47014480/131750918-51e140e4-6ed2-4c7d-863c-c5044924935e.png)

Monitor 2
![image](https://user-images.githubusercontent.com/47014480/131750941-d91c7cc6-9623-4fb3-9135-75362d868c83.png)

