### PR TITLE
feat: add polybar-hook function to i3-workspace-groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,23 +10,20 @@ groups. I find this tool useful for managing many workspaces in i3.
 
 ## Table of Contents
 
-- [i3 Workspace Groups](#i3-workspace-groups)
-  - [Table of Contents](#table-of-contents)
-  - [Background](#background)
-  - [Installation](#installation)
-  - [Configuration](#configuration)
-    - [i3 config](#i3-config)
-    - [i3-workspace-groups configuration file](#i3-workspace-groups-configuration-file)
-  - [Usage](#usage)
-    - [Example walk through](#example-walk-through)
-  - [Concepts](#concepts)
-    - [Active workspace](#active-workspace)
-    - [Active group](#active-group)
-    - [Focused group](#focused-group)
-    - [Default group](#default-group)
-  - [Limitations](#limitations)
-    - [Sway compatibility](#sway-compatibility)
-    - [Polybar](#polybar)
+- [Background](#background)
+- [Installation](#installation)
+- [Configuration](#configuration)
+  - [i3 config](#i3-config)
+  - [i3-workspace-groups configuration file](#i3-workspace-groups-configuration-file)
+- [Usage](#usage)
+  - [Example walk through](#example-walk-through)
+- [Concepts](#concepts)
+  - [Active workspace](#active-workspace)
+  - [Active group](#active-group)
+  - [Focused group](#focused-group)
+  - [Default group](#default-group)
+- [Limitations](#limitations)
+  - [Sway compatibility](#sway-compatibility)
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -269,10 +269,12 @@ test it on sway and i3 is my main window manager.
 The official `internal/i3` module does not support workspace groups.
 
 In order to display workspace information in polybar, there are two steps:
-1. Add the custom i3 workspace groups module to your polybar
-2. Run a script in the background to update polybar's display whenever an i3 window event occurs 
 
-#### 1. Add the custom i3 workspace groups module to your polybar
+1. Add the custom i3 workspace groups module to your polybar
+2. Run a script in the background to update polybar's display whenever an i3
+   window event occurs
+
+#### 1. Add the custom i3 workspace groups module to your polybar config
 
 Create an `i3-mod` module by adding the following to your polybar config:
 
@@ -289,7 +291,8 @@ Then, add the `i3-mod` module to your modules:
 modules-center = i3-mod
 ```
 
-Then, when launching polybar, do something like the following to configure the `I3_MOD_HOOK`:
+Then, when launching polybar, do something like the following to configure the
+`I3_MOD_HOOK`:
 
 ```bash
     for m in $(polybar --list-monitors | cut -d":" -f1); do
@@ -299,6 +302,9 @@ Then, when launching polybar, do something like the following to configure the `
     done
 ```
 
-#### 2. Run a script in the background to update polybar's display whenever a relevant i3 window event occurs 
+#### 2. Run a background script to update polybar's on i3 events
 
-Run the [i3-groups-polybar-module-updater](./scripts/i3-groups-polybar-module-updater) script. This script is responsible for calling the hook to update polybar whenever a relevant i3 window event occurs.
+Run the
+[i3-groups-polybar-module-updater](./scripts/i3-groups-polybar-module-updater)
+script. This script is responsible for calling the hook to update polybar
+whenever a relevant i3 window event occurs.

--- a/README.md
+++ b/README.md
@@ -295,11 +295,10 @@ Then, when launching polybar, do something like the following to configure the
 `I3_MOD_HOOK`:
 
 ```bash
-    for m in $(polybar --list-monitors | cut -d":" -f1); do
-        export MONITOR=$m;
-        export I3_MOD_HOOK="i3-workspace-groups polybar-hook --monitor \"$MONITOR\""
-        polybar -q main -c "$dir/$style/config.ini" &
-    done
+while IFS='' read -r monitor; do
+    i3_mod_hook="i3-workspace-groups polybar-hook --monitor '${monitor}'"
+    I3_MOD_HOOK="${i3_mod_hook}" polybar your-bar-name &
+done < <(polybar --list-monitors | cut -d':' -f1)
 ```
 
 #### 2. Run a background script to update polybar's on i3 events

--- a/README.md
+++ b/README.md
@@ -268,8 +268,13 @@ test it on sway and i3 is my main window manager.
 
 The official `internal/i3` module does not support workspace groups.
 
-In order to display workspace information in polybar, create an `i3-mod` module
-as follows:
+In order to display workspace information in polybar, there are two steps:
+1. Add the custom i3 workspace groups module to your polybar
+2. Run a script in the background to update polybar's display whenever an i3 window event occurs 
+
+#### 1. Add the custom i3 workspace groups module to your polybar
+
+Create an `i3-mod` module by adding the following to your polybar config:
 
 ```
 [module/i3-mod]
@@ -278,7 +283,13 @@ hook-0 = ${env:I3_MOD_HOOK}
 initial = 1
 ```
 
-Then when launching polybar do something like the following:
+Then, add the `i3-mod` module to your modules:
+
+```
+modules-center = i3-mod
+```
+
+Then, when launching polybar, do something like the following to configure the `I3_MOD_HOOK`:
 
 ```bash
     for m in $(polybar --list-monitors | cut -d":" -f1); do
@@ -287,3 +298,7 @@ Then when launching polybar do something like the following:
         polybar -q main -c "$dir/$style/config.ini" &
     done
 ```
+
+#### 2. Run a script in the background to update polybar's display whenever a relevant i3 window event occurs 
+
+Run the [i3-groups-polybar-module-updater](./scripts/i3-groups-polybar-module-updater) script. This script is responsible for calling the hook to update polybar whenever a relevant i3 window event occurs.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ groups. I find this tool useful for managing many workspaces in i3.
   - [Default group](#default-group)
 - [Limitations](#limitations)
   - [Sway compatibility](#sway-compatibility)
+  - [Polybar](#polybar)
 
 ## Background
 
@@ -267,7 +268,8 @@ test it on sway and i3 is my main window manager.
 
 The official `internal/i3` module does not support workspace groups.
 
-In order to display workspace information in polybar, create an `i3-mod` module as follows:
+In order to display workspace information in polybar, create an `i3-mod` module
+as follows:
 
 ```
 [module/i3-mod]
@@ -277,6 +279,7 @@ initial = 1
 ```
 
 Then when launching polybar do something like the following:
+
 ```bash
     for m in $(polybar --list-monitors | cut -d":" -f1); do
         export MONITOR=$m;

--- a/README.md
+++ b/README.md
@@ -10,20 +10,23 @@ groups. I find this tool useful for managing many workspaces in i3.
 
 ## Table of Contents
 
-- [Background](#background)
-- [Installation](#installation)
-- [Configuration](#configuration)
-  - [i3 config](#i3-config)
-  - [i3-workspace-groups configuration file](#i3-workspace-groups-configuration-file)
-- [Usage](#usage)
-  - [Example walk through](#example-walk-through)
-- [Concepts](#concepts)
-  - [Active workspace](#active-workspace)
-  - [Active group](#active-group)
-  - [Focused group](#focused-group)
-  - [Default group](#default-group)
-- [Limitations](#limitations)
-  - [Sway compatibility](#sway-compatibility)
+- [i3 Workspace Groups](#i3-workspace-groups)
+  - [Table of Contents](#table-of-contents)
+  - [Background](#background)
+  - [Installation](#installation)
+  - [Configuration](#configuration)
+    - [i3 config](#i3-config)
+    - [i3-workspace-groups configuration file](#i3-workspace-groups-configuration-file)
+  - [Usage](#usage)
+    - [Example walk through](#example-walk-through)
+  - [Concepts](#concepts)
+    - [Active workspace](#active-workspace)
+    - [Active group](#active-group)
+    - [Focused group](#focused-group)
+    - [Default group](#default-group)
+  - [Limitations](#limitations)
+    - [Sway compatibility](#sway-compatibility)
+    - [Polybar](#polybar)
 
 ## Background
 
@@ -262,3 +265,25 @@ all be in the default group.
 This project depends on [i3ipc](https://github.com/acrisci/i3ipc-python) for its
 interaction with i3, so should also work the same on sway. That said, I don't
 test it on sway and i3 is my main window manager.
+
+### Polybar
+
+The official `internal/i3` module does not support workspace groups.
+
+In order to display workspace information in polybar, create an `i3-mod` module as follows:
+
+```
+[module/i3-mod]
+type = custom/ipc
+hook-0 = ${env:I3_MOD_HOOK}
+initial = 1
+```
+
+Then when launching polybar do something like the following:
+```bash
+    for m in $(polybar --list-monitors | cut -d":" -f1); do
+        export MONITOR=$m;
+        export I3_MOD_HOOK="i3-workspace-groups polybar-hook --monitor \"$MONITOR\""
+        polybar -q main -c "$dir/$style/config.ini" &
+    done
+```

--- a/scripts/i3-workspace-groups
+++ b/scripts/i3-workspace-groups
@@ -289,7 +289,8 @@ def get_monitor_active_group(controller, groups_to_workspaces, monitor):
     min_global = float('inf')
     for (group, workspaces) in groups_to_workspaces.items():
         for ws in workspaces:
-            if _get_workspace_field(controller, ws, 'monitor') == monitor:
+            if not monitor or _get_workspace_field(controller, ws,
+                                                   'monitor') == monitor:
                 global_number = _get_workspace_field(controller, ws,
                                                      'global_number')
                 if global_number and global_number < min_global:
@@ -309,7 +310,8 @@ def _print_polybar_hook(controller, args):
 
         parsed_names_dict = {}
         for ws in workspaces:
-            if _get_workspace_field(controller, ws, 'monitor') == args.monitor:
+            if not args.monitor or _get_workspace_field(
+                    controller, ws, 'monitor') == args.monitor:
                 local_number = _get_workspace_field(controller, ws,
                                                     'local_number')
                 focused = _get_workspace_field(controller, ws, 'focused')

--- a/scripts/i3-workspace-groups
+++ b/scripts/i3-workspace-groups
@@ -285,7 +285,7 @@ def serve(i3_connection, server_addr):
 
 
 def get_monitor_active_group(controller, groups_to_workspaces, monitor):
-    active_group = ""
+    active_group = ''
     min_global = float('inf')
     for (group, workspaces) in groups_to_workspaces.items():
         for ws in workspaces:
@@ -313,20 +313,20 @@ def _print_polybar_hook(controller, args):
                 local_number = _get_workspace_field(controller, ws,
                                                     'local_number')
                 focused = _get_workspace_field(controller, ws, 'focused')
-                parsed_names_dict[local_number] = {"focused": focused}
+                parsed_names_dict[local_number] = {'focused': focused}
 
         if len(parsed_names_dict) != 0:
-            parsed_names = "".join([
-                f"%{{u{args.line_color}}}%{{+u}} {local_number} %{{-u}}"
-                if parsed_names_dict[local_number]["focused"] else
-                f" {local_number} "
+            parsed_names = ''.join([
+                f'%{{u{args.line_color}}}%{{+u}} {local_number} %{{-u}}'
+                if parsed_names_dict[local_number]['focused'] else
+                f' {local_number} '
                 for local_number in sorted(parsed_names_dict.keys())
             ])
 
-            formatted_group = f"%{{o{args.line_color}}}%{{+o}}{group}:%{{-o}}" if active_group == group else f"{group}:"
-            res.append(f"{formatted_group}{parsed_names}")
+            formatted_group = f'%{{o{args.line_color}}}%{{+o}}{group}:%{{-o}}' if active_group == group else f'{group}:'
+            res.append(f'{formatted_group}{parsed_names}')
 
-    print(" |  ".join(res))
+    print(' |  '.join(res))
 
 
 # pylint: disable=too-many-branches

--- a/scripts/i3-workspace-groups
+++ b/scripts/i3-workspace-groups
@@ -316,8 +316,7 @@ def _print_polybar_hook(controller, args):
                                                     'local_number')
                 focused = _get_workspace_field(controller, ws, 'focused')
                 parsed_names_dict[local_number] = {'focused': focused}
-
-        if len(parsed_names_dict) != 0:
+        if parsed_names_dict:
             parsed_names = ''.join([
                 f'%{{u{args.line_color}}}%{{+u}} {local_number} %{{-u}}'
                 if parsed_names_dict[local_number]['focused'] else

--- a/scripts/i3-workspace-groups
+++ b/scripts/i3-workspace-groups
@@ -300,34 +300,58 @@ def get_monitor_active_group(controller, groups_to_workspaces, monitor):
 
 
 def _print_polybar_hook(controller, args):
+    # Grab information about the i3 workspace states
     workspaces = controller.get_tree().workspaces()
     group_to_workspaces = workspace_names.get_group_to_workspaces(workspaces)
     active_group = get_monitor_active_group(controller, group_to_workspaces,
                                             args.monitor)
-    res = []
+
+    # Lambdas for formatting polybar text with overline and underline
+    def polybar_overline_format(text, color):
+        return f'%{{o{color}}}%{{+o}}{text}:%{{-o}}' if color else text
+
+    def polybar_underline_format(text, color):
+        return f'%{{u{color}}}%{{+u}}{text}%{{-u}}' if color else text
+
+    formatted_group_info = []
+
     for group in sorted(group_to_workspaces.keys()):
         workspaces = group_to_workspaces[group]
 
+        # Build parsed_names_dict to include the local numbers of the workspaces
+        # relevant to this monitor and group
         parsed_names_dict = {}
         for ws in workspaces:
+            # When monitor is specified, only include workspaces
+            # on that monitor. Otherwise, include all workspaces.
             if not args.monitor or _get_workspace_field(
                     controller, ws, 'monitor') == args.monitor:
                 local_number = _get_workspace_field(controller, ws,
                                                     'local_number')
                 focused = _get_workspace_field(controller, ws, 'focused')
                 parsed_names_dict[local_number] = {'focused': focused}
+
         if parsed_names_dict:
             parsed_names = ''.join([
-                f'%{{u{args.line_color}}}%{{+u}} {local_number} %{{-u}}'
-                if parsed_names_dict[local_number]['focused'] else
-                f' {local_number} '
+                polybar_underline_format(
+                    f" {local_number} ", args.line_color
+                    if parsed_names_dict[local_number]['focused'] else None)
                 for local_number in sorted(parsed_names_dict.keys())
             ])
 
-            formatted_group = f'%{{o{args.line_color}}}%{{+o}}{group}:%{{-o}}' if active_group == group else f'{group}:'
-            res.append(f'{formatted_group}{parsed_names}')
+            formatted_group = polybar_overline_format(
+                f"{group}:",
+                args.line_color if active_group == group else None)
 
-    print(' |  '.join(res))
+            formatted_group_info.append(f'{formatted_group}{parsed_names}')
+
+    # Print each of the formatted group infos
+    # separated by pipes.
+    # The result looks something like:
+    # Work: 1  2  |  Play: 3  5
+    # Where "Work" and "Play" are the group names
+    # and "1", "2", "3", and "5" are the local numbers.
+    print(' |  '.join(formatted_group_info))
 
 
 # pylint: disable=too-many-branches

--- a/scripts/i3-workspace-groups
+++ b/scripts/i3-workspace-groups
@@ -85,13 +85,12 @@ def _create_args_parser() -> cli.ArgumentParserNoExit:
     subparsers.required = True
 
     polybar_hook_parser = subparsers.add_parser(
-        'polybar-hook', help='Return text for displaying to polybar i3-mod module')
-    polybar_hook_parser.add_argument(
-        '--line-color', type=str, default="#ff9900"
-    )
-    polybar_hook_parser.add_argument(
-        '--monitor', type=str
-    )
+        'polybar-hook',
+        help='Return text for displaying to polybar i3-mod module')
+    polybar_hook_parser.add_argument('--line-color',
+                                     type=str,
+                                     default="#ff9900")
+    polybar_hook_parser.add_argument('--monitor', type=str)
 
     list_groups_parser = subparsers.add_parser(
         'list-groups', help='List the groups of the current workspaces.')
@@ -284,22 +283,26 @@ def serve(i3_connection, server_addr):
             # Clean up the connection
             connection.close()
 
+
 def get_monitor_active_group(controller, groups_to_workspaces, monitor):
     active_group = ""
     min_global = float('inf')
     for (group, workspaces) in groups_to_workspaces.items():
         for ws in workspaces:
             if _get_workspace_field(controller, ws, 'monitor') == monitor:
-                global_number = _get_workspace_field(controller, ws, 'global_number')
+                global_number = _get_workspace_field(controller, ws,
+                                                     'global_number')
                 if global_number and global_number < min_global:
                     active_group = group
                     min_global = global_number
     return active_group
 
+
 def _print_polybar_hook(controller, args):
     workspaces = controller.get_tree().workspaces()
     group_to_workspaces = workspace_names.get_group_to_workspaces(workspaces)
-    active_group = get_monitor_active_group(controller, group_to_workspaces, args.monitor)
+    active_group = get_monitor_active_group(controller, group_to_workspaces,
+                                            args.monitor)
     res = []
     for group in sorted(group_to_workspaces.keys()):
         workspaces = group_to_workspaces[group]
@@ -307,16 +310,24 @@ def _print_polybar_hook(controller, args):
         parsed_names_dict = {}
         for ws in workspaces:
             if _get_workspace_field(controller, ws, 'monitor') == args.monitor:
-                local_number = _get_workspace_field(controller, ws, 'local_number')
+                local_number = _get_workspace_field(controller, ws,
+                                                    'local_number')
                 focused = _get_workspace_field(controller, ws, 'focused')
                 parsed_names_dict[local_number] = {"focused": focused}
-        
+
         if len(parsed_names_dict) != 0:
-            parsed_names = "".join([f"%{{u{args.line_color}}}%{{+u}} {local_number} %{{-u}}" if parsed_names_dict[local_number]["focused"] else f" {local_number} " for local_number in sorted(parsed_names_dict.keys())])
+            parsed_names = "".join([
+                f"%{{u{args.line_color}}}%{{+u}} {local_number} %{{-u}}"
+                if parsed_names_dict[local_number]["focused"] else
+                f" {local_number} "
+                for local_number in sorted(parsed_names_dict.keys())
+            ])
+
             formatted_group = f"%{{o{args.line_color}}}%{{+o}}{group}:%{{-o}}" if active_group == group else f"{group}:"
             res.append(f"{formatted_group}{parsed_names}")
 
     print(" | ".join(res))
+
 
 # pylint: disable=too-many-branches
 # pylint: disable-next=no-else-return

--- a/scripts/i3-workspace-groups
+++ b/scripts/i3-workspace-groups
@@ -326,7 +326,7 @@ def _print_polybar_hook(controller, args):
             formatted_group = f"%{{o{args.line_color}}}%{{+o}}{group}:%{{-o}}" if active_group == group else f"{group}:"
             res.append(f"{formatted_group}{parsed_names}")
 
-    print(" | ".join(res))
+    print(" |  ".join(res))
 
 
 # pylint: disable=too-many-branches

--- a/scripts/i3-workspace-groups
+++ b/scripts/i3-workspace-groups
@@ -83,6 +83,16 @@ def _create_args_parser() -> cli.ArgumentParserNoExit:
     cli.add_workspace_naming_args(parser)
     subparsers = parser.add_subparsers(dest='command')
     subparsers.required = True
+
+    polybar_hook_parser = subparsers.add_parser(
+        'polybar-hook', help='Return text for displaying to polybar i3-mod module')
+    polybar_hook_parser.add_argument(
+        '--line-color', type=str, default="#ff9900"
+    )
+    polybar_hook_parser.add_argument(
+        '--monitor', type=str
+    )
+
     list_groups_parser = subparsers.add_parser(
         'list-groups', help='List the groups of the current workspaces.')
     list_groups_parser.add_argument(
@@ -274,6 +284,39 @@ def serve(i3_connection, server_addr):
             # Clean up the connection
             connection.close()
 
+def get_monitor_active_group(controller, groups_to_workspaces, monitor):
+    active_group = ""
+    min_global = float('inf')
+    for (group, workspaces) in groups_to_workspaces.items():
+        for ws in workspaces:
+            if _get_workspace_field(controller, ws, 'monitor') == monitor:
+                global_number = _get_workspace_field(controller, ws, 'global_number')
+                if global_number and global_number < min_global:
+                    active_group = group
+                    min_global = global_number
+    return active_group
+
+def _print_polybar_hook(controller, args):
+    workspaces = controller.get_tree().workspaces()
+    group_to_workspaces = workspace_names.get_group_to_workspaces(workspaces)
+    active_group = get_monitor_active_group(controller, group_to_workspaces, args.monitor)
+    res = []
+    for group in sorted(group_to_workspaces.keys()):
+        workspaces = group_to_workspaces[group]
+
+        parsed_names_dict = {}
+        for ws in workspaces:
+            if _get_workspace_field(controller, ws, 'monitor') == args.monitor:
+                local_number = _get_workspace_field(controller, ws, 'local_number')
+                focused = _get_workspace_field(controller, ws, 'focused')
+                parsed_names_dict[local_number] = {"focused": focused}
+        
+        if len(parsed_names_dict) != 0:
+            parsed_names = "".join([f"%{{u{args.line_color}}}%{{+u}} {local_number} %{{-u}}" if parsed_names_dict[local_number]["focused"] else f" {local_number} " for local_number in sorted(parsed_names_dict.keys())])
+            formatted_group = f"%{{o{args.line_color}}}%{{+o}}{group}:%{{-o}}" if active_group == group else f"{group}:"
+            res.append(f"{formatted_group}{parsed_names}")
+
+    print(" | ".join(res))
 
 # pylint: disable=too-many-branches
 # pylint: disable-next=no-else-return
@@ -284,6 +327,8 @@ def run_command(i3_connection, args):
         i3_proxy.I3Proxy(i3_connection, args.dry_run), config)
     if args.command == 'list-groups':
         return '\n'.join(controller.list_groups(args.focused_monitor_only))
+    if args.command == 'polybar-hook':
+        _print_polybar_hook(controller, args)
     if args.command == 'list-workspaces':
         return _print_workspaces(controller, args)
     if args.command == 'workspace-number':


### PR DESCRIPTION
## What's This

Add a `polybar-hook` command to `i3-workspace-groups` for displaying workspace information in polybar.

This provides similar functionality to `i3-groups-polybar-module`, but it's written in python instead of bash to get access to the existing python code and make it easier to read/write.

### Implementation Details

- Relatively small amount of code.
- Add a function `get_monitor_active_group` for grabbing the active group of a monitor (didn't see an existing function for this, may have missed it)
- The `_print_polybar_hook` function prints out a string which is read by polybar.
- The active workspace group for any given monitor is indicated with an overline.
- The active workspace for any given monitor is indicated with an underline 
- Workspace groups are displayed in lexicographical order (this means they don't move around when you change the active workspace group)

### Screenshots

This is what it looks like with 6 virtual monitors:

![image](https://user-images.githubusercontent.com/47014480/198860237-94ef59d5-921f-4bc4-b71a-e3fa835c0693.png)

### Documentation

Added the following to the readme:

#### Polybar

The official `internal/i3` module does not support workspace groups.

In order to display workspace information in polybar, create an `i3-mod` module as follows:

```
[module/i3-mod]
type = custom/ipc
hook-0 = ${env:I3_MOD_HOOK}
initial = 1
```

Then when launching polybar do something like the following:
```bash
    for m in $(polybar --list-monitors | cut -d":" -f1); do
        export MONITOR=$m;
        export I3_MOD_HOOK="i3-workspace-groups polybar-hook --monitor \"$MONITOR\""
        polybar -q main -c "$dir/$style/config.ini" &
    done
```

### Misc

This replaces #49.