### PR TITLE
fix: polybar overline format function

### DIFF
--- a/scripts/i3-workspace-groups
+++ b/scripts/i3-workspace-groups
@@ -308,7 +308,7 @@ def _print_polybar_hook(controller, args):
 
     # Lambdas for formatting polybar text with overline and underline
     def polybar_overline_format(text, color):
-        return f'%{{o{color}}}%{{+o}}{text}:%{{-o}}' if color else text
+        return f'%{{o{color}}}%{{+o}}{text}%{{-o}}' if color else text
 
     def polybar_underline_format(text, color):
         return f'%{{u{color}}}%{{+u}}{text}%{{-u}}' if color else text


### PR DESCRIPTION
## What's This

One character change to fix polybar overline format function. It was incorrectly adding an extra ":" to the formatted text.