### PR TITLE
Use Async when Connecting i3ipc

### DIFF
--- a/scripts/i3-groups-polybar-module-updater
+++ b/scripts/i3-groups-polybar-module-updater
@@ -1,29 +1,25 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
+
+from i3ipc.aio import Connection
+from i3ipc import Event
 import subprocess
 
-import i3ipc
-
+import asyncio
 
 def _update_polybar(*_):
-    # As of 2021-10-15 and PR #2539 [1] running the hook action is deprecated.
-    # We should switch to the commented out alternative, but we'll wait till
-    # this change is a bit older to reduce the risk that we break the setup of
-    # people that run older versions of polybar.
-    # [1] https://github.com/polybar/polybar/pull/2539
-    # subprocess.run(['polybar-msg', 'action', '#i3-mod.hook.0'], check=False)
-    subprocess.run(['polybar-msg', 'hook', 'i3-mod', '1'], check=False)
+    subprocess.run(['polybar-msg', 'action', '#i3-mod.hook.0'], check=False)
 
+async def main():
+    i3 = await Connection(auto_reconnect=True).connect()
 
-def main():
     _update_polybar()
-    i3 = i3ipc.Connection()
-    i3.on('workspace::focus', _update_polybar)
-    i3.on('workspace::init', _update_polybar)
-    i3.on('workspace::rename', _update_polybar)
-    i3.on('workspace::move', _update_polybar)
-    i3.on('workspace::empty', _update_polybar)
-    i3.main()
+    i3.on(Event.WORKSPACE_FOCUS, _update_polybar)
+    i3.on(Event.WORKSPACE_INIT , _update_polybar)
+    i3.on(Event.WORKSPACE_RENAME, _update_polybar)
+    i3.on(Event.WORKSPACE_MOVE, _update_polybar)
+    i3.on(Event.WORKSPACE_EMPTY, _update_polybar)
 
+    await i3.main()
 
 if __name__ == '__main__':
-    main()
+    asyncio.get_event_loop().run_until_complete(main())

--- a/scripts/i3-groups-polybar-module-updater
+++ b/scripts/i3-groups-polybar-module-updater
@@ -22,4 +22,6 @@ async def main():
     await i3.main()
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())

--- a/scripts/i3-groups-polybar-module-updater
+++ b/scripts/i3-groups-polybar-module-updater
@@ -7,7 +7,13 @@ import subprocess
 import asyncio
 
 def _update_polybar(*_):
-    subprocess.run(['polybar-msg', 'action', '#i3-mod.hook.0'], check=False)
+    # As of 2021-10-15 and PR #2539 [1] running the hook action is deprecated.
+    # We should switch to the commented out alternative, but we'll wait till
+    # this change is a bit older to reduce the risk that we break the setup of
+    # people that run older versions of polybar.
+    # [1] https://github.com/polybar/polybar/pull/2539
+    # subprocess.run(['polybar-msg', 'action', '#i3-mod.hook.0'], check=False)
+    subprocess.run(['polybar-msg', 'hook', 'i3-mod', '1'], check=False)
 
 async def main():
     i3 = await Connection(auto_reconnect=True).connect()
@@ -22,6 +28,4 @@ async def main():
     await i3.main()
 
 if __name__ == '__main__':
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(main())
+    asyncio.run(main())


### PR DESCRIPTION
I was getting some errors when calling this script because i3 was being used before it was fully connected. Following the [example](https://github.com/altdesktop/i3ipc-python#asyncio-support), these can be averted by awaiting the connection.

It also seems about time to switch from the deprecated hook calls. 