### PR TITLE
Fix polybar module updater coroutine error

### DIFF
--- a/i3wsgroups/polybar_module_updater.py
+++ b/i3wsgroups/polybar_module_updater.py
@@ -17,7 +17,7 @@ def _update_polybar(*_):
     subprocess.run(['polybar-msg', 'hook', 'i3-mod', '1'], check=False)
 
 
-async def main():
+async def main_async():
     i3 = await Connection(auto_reconnect=True).connect()
 
     _update_polybar()
@@ -29,6 +29,9 @@ async def main():
 
     await i3.main()
 
+def main():
+    asyncio.run(main())
+
 
 if __name__ == '__main__':
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
Fixes #65 

The script for the updater was calling main, but main is a coroutine... fixed that by changing main to be a synchronous function.